### PR TITLE
CentOS4.8 テンプレートの更新

### DIFF
--- a/CentOS-4.8-i386-ja/definition.rb
+++ b/CentOS-4.8-i386-ja/definition.rb
@@ -1,6 +1,6 @@
 Veewee::Definition.declare({
-  :cpu_count => '1', :memory_size=> '512',
-  :disk_size => '10140', :disk_format => 'VDI',:hostiocache => 'off',:ioapic => 'on', :pae => 'on',
+  :cpu_count => '1', :memory_size=> '2048',
+  :disk_size => '40560', :disk_format => 'VDI',:hostiocache => 'off',:ioapic => 'on', :pae => 'on',
   :os_type_id => 'RedHat',
   :iso_file => "CentOS-4.8-i386-bin-DVD.iso", :iso_src => "", :iso_md5 => "", :iso_download_timeout => 1000,
   :iso_download_instructions => "This iso is no more available, for instructions see http://vault.centos.org/4.8/isos/i386/",

--- a/CentOS-4.8-i386-ja/ks.cfg
+++ b/CentOS-4.8-i386-ja/ks.cfg
@@ -17,9 +17,9 @@ bootloader --location=mbr
 # Note that any partitions you deleted are not expressed
 # here so unless you clear all partitions first, this is
 # not guaranteed to work
-clearpart --all --drives=hda --initlabel
-part /boot --fstype ext3 --size=100 --ondisk=hda
-part pv.2 --size=0 --grow --ondisk=hda
+clearpart --all --initlabel
+part /boot --fstype ext3 --size=100
+part pv.2 --size=0 --grow
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=528 --grow --maxsize=1056
 logvol / --fstype ext3 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow

--- a/CentOS-4.8-i386-ja/postinstall.sh
+++ b/CentOS-4.8-i386-ja/postinstall.sh
@@ -20,6 +20,21 @@ yum -y erase  gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
 
 yum -y clean all
 
+# Update sudo
+wget ftp://ftp.sudo.ws/pub/sudo/sudo-1.8.10p2.tar.gz
+tar xzvf sudo-1.8.10p2.tar.gz
+cd sudo-1.8.10p2
+./configure
+make
+make install
+cd ..
+cp /etc/sudoers /tmp/sudoers
+echo "vagrant ALL=(ALL:ALL) NOPASSWD:ALL"  >> /tmp/sudoers
+rm -rf sudo-1.8.10p2
+rm sudo-1.8.10p2.tar.gz
+yum -y erase sudo
+mv /tmp/sudoers /etc/sudoers
+
 #Installing ruby
 wget http://rubyforge.org/frs/download.php/71096/ruby-enterprise-1.8.7-2010.02.tar.gz
 tar xzvf ruby-enterprise-1.8.7-2010.02.tar.gz

--- a/CentOS-4.8-i386-ja/postinstall.sh
+++ b/CentOS-4.8-i386-ja/postinstall.sh
@@ -11,7 +11,7 @@ sed -i "s/mirror.centos.org\/centos\/\$releasever/vault.centos.org\/4.9/g" /etc/
 
 yum -y install gcc bzip2 make kernel-devel-`uname -r`
 
-#yum -y update
+yum -y update
 #yum -y upgrade
 
 yum -y install gcc-c++ zlib-devel openssl-devel readline-devel sqlite3-devel

--- a/CentOS-4.8-i386-ja/postinstall.sh
+++ b/CentOS-4.8-i386-ja/postinstall.sh
@@ -36,16 +36,20 @@ yum -y erase sudo
 mv /tmp/sudoers /etc/sudoers
 
 #Installing ruby
-wget http://rubyforge.org/frs/download.php/71096/ruby-enterprise-1.8.7-2010.02.tar.gz
-tar xzvf ruby-enterprise-1.8.7-2010.02.tar.gz
-./ruby-enterprise-1.8.7-2010.02/installer -a /opt/ruby --no-dev-docs --dont-install-useful-gems
+wget ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz
+tar xzvf ruby-1.9.3-p545.tar.gz
+cd ruby-1.9.3-p545
+./configure --exec-prefix=/opt/ruby --disable-install-doc --disable-rubygems
+make
+make install
+cd ..
 echo 'PATH=$PATH:/opt/ruby/bin'> /etc/profile.d/rubyenterprise.sh
-rm -rf ./ruby-enterprise-1.8.7-2010.02/
-rm ruby-enterprise-1.8.7-2010.02.tar.gz
+rm -rf ./ruby-1.9.3-p545/
+rm ruby-1.9.3-p545.tar.gz
 
 #Installing chef & Puppet
-/opt/ruby/bin/gem install chef --no-ri --no-rdoc
-/opt/ruby/bin/gem install puppet --no-ri --no-rdoc
+#/opt/ruby/bin/gem install chef --no-ri --no-rdoc
+#/opt/ruby/bin/gem install puppet --no-ri --no-rdoc
 
 #Installing vagrant keys
 mkdir /home/vagrant/.ssh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Veewee-definitions
+
+## 構築方法
+
+※CentOS-4.8-i386-ja での構築方法
+
+veeweeをインストールする。
+
+	$ git clone git://github.com/jedi4ever/veewee.git
+
+Veewee-definitionsをveewee/definitionsにコピーする。
+
+必要なISOファイルをveewee/isoにコピーしておく。
+
+ VBOXを作成する。
+
+	$ bundle exec veewee vbox build CentOS-4.8-i386-ja --force
+
+Vagrantのboxファイルをエクスポートする。
+
+	$ bundle exec veewee vbox export CentOS-4.8-i386-ja --force
+
+Vagrant でサーバーを起動する。
+
+	$ vagrant box add 'CentOS-4.8-i386-ja' 'CentOS-4.8-i386-ja.box' --force
+	$ vagrant init 'CentOS-4.8-i386-ja'
+	$ vagrant up
+	$ vagrant ssh
+
+## 残件
+
+*　CentOS-4.8-i386-ja では 、ライブラリが足りないのでchef & Puppetをインストールしないようにコメントアウトしておく。
+
+## 開発者
+
+[ikikko](https://github.com/ikikko)


### PR DESCRIPTION
CentOS4.8 でsudoが古くてVagrantでエラーになっていたので、新しいバージョンに入れ替えるようにテンプレートを更新しました。
